### PR TITLE
Implement redis authorization. (closes #4)

### DIFF
--- a/lib/telDCache.js
+++ b/lib/telDCache.js
@@ -13,18 +13,30 @@ function TelDCache() {
 
     function resolveSuccess() {
       _self._state.connected = true;
+
+      // We can assume this, 'ready' is only emitted after conn/auth.
+      _self._state.authorized = true;
+
       connectionDeferred.resolve(_self._state);
     }
 
     function resolveError(err) {
       _self._state.connected = false;
+      _self._state.authorized = err.message.indexOf('NOAUTH') === -1;
+      
       _self._state.error = err;
       connectionDeferred.reject(_self._state);
     }
 
     var connectionDeferred = q.defer();
 
-    _client = redis.createClient(options.port, options.host);
+    var redisOptions = {};
+
+    if(options.password) {
+      redisOptions.auth_pass = options.password;
+    }
+
+    _client = redis.createClient(options.port, options.host, redisOptions);
     _client.on('ready', resolveSuccess);
     _client.on('error', resolveError);
 
@@ -36,6 +48,8 @@ function TelDCache() {
 
     function handleDisconnect() {
       _self._state.connected = false;
+      delete _self._state.authorized;
+
       disconnectDfd.resolve(_self._state);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telogical/teldcache",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A durable caching implementation built upon TelQ and Redis (current implementation).",
   "repository": {
     "type": "git",


### PR DESCRIPTION
  Tests were expanded and refactored to consider that
- We are always trying to connect to a secured cache. Though, it seems
  in a lot of situations peoples' Redis servers are left open because
  they're behind a firewall. This sounds like a bad practice.
- Case for giving a good password
  - Sets the authorized flag on `_state`
  - Disconnection test expects the connection promise to resolve
- Case for giving a bad or missing password
  - Expects `false` for the `authorized` flag
  - Disconnection test expects the connection promise to reject
